### PR TITLE
feat: handling member not found when connecting

### DIFF
--- a/discord/interactions/connectCommand.ts
+++ b/discord/interactions/connectCommand.ts
@@ -26,7 +26,13 @@ export const handleConnectCommand = async (
   client: Client<boolean>,
   restClient: REST
 ) => {
-  if (!interaction.member) return;
+  if (!interaction.member) {
+    await interaction.reply({
+      content: "An error occured: Member not found",
+      ephemeral: true,
+    });
+    return;
+  }
 
   const guildId = interaction.guildId;
   const userId = interaction.member?.user?.id;


### PR DESCRIPTION
If the member is not found, we should not just cancel the command, but also answer the user, so that it's easier to debug. As following:
![image](https://github.com/carbonable-labs/starky/assets/60229704/847dd409-e25f-420c-b79d-54f32070ca2e)